### PR TITLE
Add method to find the job applications for a specific candidate

### DIFF
--- a/app/graphql/types/candidate_type.rb
+++ b/app/graphql/types/candidate_type.rb
@@ -3,23 +3,41 @@ module Types
     field :id, ID, null: false do
       description "This candidate's ID."
     end
+
     field :first_name, String, null: true do
       description "This candidate's first name."
     end
+
     field :last_name, String, null: true do
       description "This candidate's last name."
     end
+
     field :email, String, null: true do
       description "This candidate's email."
     end
+
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false do
       description "The date/time that this candidate was created at."
     end
+
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false do
       description "The date/time that this candidate was last updated at."
     end
-    field :job_application, JobApplicationType, null: true do
+
+    field :job_applications, [JobApplicationType], null: true do
       description "This candidate's job applications."
     end
+
+    def job_applications
+      object.job_applications
+    end
+
+    # field :job_app_count, Integer, null: true do
+    #   description "Count of the apps for a candidate"
+    # end
+    #
+    # def job_app_count
+    #   object.job_applications.count
+    # end
   end
 end


### PR DESCRIPTION
## Changes
Interview Challange: 

## Description of changes
- Added a method to be able to list the job applications associated with a user.

## Checklist
- [x] Completes Story
- [x] Did I have any issues? If yes, what were they?
  - Description of Issues: I could not get the connection to work between the candidate and their job applications. I was not sure why it was not working until I moved my method from the query type file to the candidate type file and made a corresponding method to the field for job applications. This took much longer for me to figure out than I would have liked, but hey, that's showbiz.
- [x] Commented on changed files

## Other Comments: 
- Here are my first 4 queries that are giving me the correct information requested from each user story (stories 1-4):
```{
   allCandidates {
    id
    firstName
    lastName
    email
  }
}
```
```
{
  candidate(id: 1) {
    id
    firstName
    lastName
    email

  }
}
```
```
{
  jobApplications {
    id
    jobPostingId
    candidateId
  }
}
```
```
{
  candidate(id: 1) {
    id
    email
    jobApplications {
      id
      jobPostingId
      candidateId
    }
  }
}
```
